### PR TITLE
Added ERIGON Client support (#21)

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -2,6 +2,9 @@ export const NetworkType = {
   MAINNET: 'MAINNET',
   TESTNET: 'TESTNET',
   RINKEBY: 'RINKEBY',
+  GOERLI: 'GOERLI',
+  ROPSTEN: 'ROPSTEN',
+  KOVAN: 'KOVAN',
 };
 
 export const NodeType = {
@@ -15,6 +18,7 @@ export const NodeClient = {
   OPEN_ETHEREUM: 'OPEN_ETHEREUM',
   PARITY: 'PARITY',
   NETHERMIND: 'NETHERMIND',
+  ERIGON: 'ERIGON',
 };
 
 export const Role = {

--- a/src/interfaces/crypto-node.ts
+++ b/src/interfaces/crypto-node.ts
@@ -56,7 +56,7 @@ export interface CryptoNode {
   _logOutput(output: string): void;
   _logClose(exitCode: number): void;
   _requestTimeout: number;
-  start(): Promise<ChildProcess>;
+  start(): Promise<ChildProcess | Array<ChildProcess>>;
   stop(): void;
   isRunning(): Promise<boolean>;
   toObject(): CryptoNodeData;

--- a/src/types/avalanche/avalanche.ts
+++ b/src/types/avalanche/avalanche.ts
@@ -168,6 +168,12 @@ export class Avalanche extends Bitcoin {
     NetworkType.MAINNET,
   ];
 
+  static networkTypesByClient = {
+    [NodeClient.CORE]: [
+      NetworkType.MAINNET,
+    ],
+  };
+
   static roles = [
     Role.NODE,
   ];

--- a/src/types/binance-sc/binance-sc.ts
+++ b/src/types/binance-sc/binance-sc.ts
@@ -123,6 +123,12 @@ export class BinanceSC extends Ethereum {
     NetworkType.MAINNET,
   ];
 
+  static networkTypesByClient = {
+    [NodeClient.GETH]: [
+      NetworkType.MAINNET,
+    ],
+  };
+
   static roles = [
     Role.NODE,
   ];

--- a/src/types/bitcoin-cash/bitcoin-cash.ts
+++ b/src/types/bitcoin-cash/bitcoin-cash.ts
@@ -66,6 +66,13 @@ export class BitcoinCash extends Bitcoin {
     NetworkType.TESTNET,
   ];
 
+  static networkTypesByClient = {
+    [NodeClient.CORE]: [
+      NetworkType.MAINNET,
+      NetworkType.TESTNET,
+    ],
+  };
+
   static roles = [
     Role.NODE,
   ];

--- a/src/types/bitcoin/bitcoin.ts
+++ b/src/types/bitcoin/bitcoin.ts
@@ -67,6 +67,13 @@ export class Bitcoin extends EventEmitter implements CryptoNodeData, CryptoNode,
     NetworkType.TESTNET,
   ];
 
+  static networkTypesByClient = {
+    [NodeClient.CORE]: [
+      NetworkType.MAINNET,
+      NetworkType.TESTNET,
+    ],
+  };
+
   static roles = [
     Role.NODE,
   ];
@@ -82,8 +89,12 @@ export class Bitcoin extends EventEmitter implements CryptoNodeData, CryptoNode,
   };
 
   static defaultCPUs = 4;
+  static defaultArchivalCPUs = 8;
+  static rpcDaemonCPUs = 2;
 
   static defaultMem = 8192;
+  static defaultArchivalMem = 16384;
+  static rpcDaemonMem = 2048;
 
   static generateConfig(client = Bitcoin.clients[0], network = NetworkType.MAINNET, peerPort = Bitcoin.defaultPeerPort[NetworkType.MAINNET], rpcPort = Bitcoin.defaultRPCPort[NetworkType.MAINNET], rpcUsername = generateRandom(), rpcPassword = generateRandom()): string {
     switch(client) {
@@ -284,7 +295,7 @@ export class Bitcoin extends EventEmitter implements CryptoNodeData, CryptoNode,
       this.rpcPassword);
   }
 
-  async start(): Promise<ChildProcess> {
+  async start(): Promise<ChildProcess | Array<ChildProcess>> {
     const versions = Bitcoin.versions(this.client, this.network);
     const versionData = versions.find(({ version }) => version === this.version) || versions[0];
     if(!versionData)

--- a/src/types/dash/dash.ts
+++ b/src/types/dash/dash.ts
@@ -66,6 +66,13 @@ export class Dash extends Bitcoin {
     NetworkType.TESTNET,
   ];
 
+  static networkTypesByClient = {
+    [NodeClient.CORE]: [
+      NetworkType.MAINNET,
+      NetworkType.TESTNET,
+    ],
+  };
+
   static roles = [
     Role.NODE,
   ];

--- a/src/types/ethereum/ethereum.ts
+++ b/src/types/ethereum/ethereum.ts
@@ -8,7 +8,7 @@ import fs from 'fs-extra';
 import path from 'path';
 import os from 'os';
 import { Bitcoin } from '../bitcoin/bitcoin';
-import { filterVersionsByNetworkType } from '../../util';
+import { aggregateStats, filterVersionsByNetworkType } from '../../util';
 
 const coreConfig = `
 [Eth]
@@ -26,11 +26,20 @@ HTTPModules = ["net", "web3", "eth"]
 ListenAddr = ":{{PEER_PORT}}"
 `;
 
+export interface EthCryptoNodeData extends CryptoNodeData {
+  dockerRpcDaemonCPUs?: number;
+  dockerRpcDaemonMem?: number;
+}
+
+export interface EthVersionDockerImage extends VersionDockerImage {
+  generateRpcRuntimeArgs?: (data: EthCryptoNodeData) => string;
+}
+
 export class Ethereum extends Bitcoin {
 
   static versions(client: string, networkType: string): VersionDockerImage[] {
     client = client || Ethereum.clients[0];
-    let versions: VersionDockerImage[];
+    let versions: EthVersionDockerImage[];
     switch(client) {
       case NodeClient.GETH:
         versions = [
@@ -133,6 +142,49 @@ export class Ethereum extends Bitcoin {
           },
         ];
         break;
+      case NodeClient.ERIGON:
+        versions = [
+          {
+            version: '2022.01.2',
+            clientVersion: '2022.01.2',
+            image: 'thorax/erigon:v2022.01.02',
+            dataDir: '/home/erigon/data',
+            walletDir: '', // not required
+            configPath: '', // not required
+            networks: [
+              // added only supported chains by Pocket Network as Chains
+              NetworkType.MAINNET,
+              NetworkType.RINKEBY,
+              NetworkType.GOERLI,
+              NetworkType.ROPSTEN,
+              NetworkType.KOVAN,
+            ],
+            breaking: false,
+            generateRuntimeArgs(data: EthCryptoNodeData): string {
+              const { network = '', peerPort } = data;
+
+              return ' erigon ' + [
+                '--datadir=/home/erigon/data',
+                `--port ${peerPort}`, // default to 30303
+                `--chain ${network.toLowerCase()}`,
+                '--private.api.addr=0.0.0.0:9090',
+                '--private.api.addr=0.0.0.0:9090',
+              ].join(' ');
+            },
+            generateRpcRuntimeArgs(data: EthCryptoNodeData): string {
+              const { id } = data;
+              return ' rpcdaemon ' + [
+                `--private.api.addr=${id}:9090`,
+                `--txpool.api.addr=${id}:9090`,
+                '--http.addr=0.0.0.0',
+                '--http.vhosts=*',
+                '--http.corsdomain=*',
+                '--http.api=eth,erigon,web3,net,debug,trace,txpool',
+              ].join(' ');
+            },
+          },
+        ];
+        break;
       default:
         versions = [];
     }
@@ -141,6 +193,7 @@ export class Ethereum extends Bitcoin {
 
   static clients = [
     NodeClient.GETH,
+    NodeClient.ERIGON,
   ];
 
   static nodeTypes = [
@@ -151,7 +204,24 @@ export class Ethereum extends Bitcoin {
   static networkTypes = [
     NetworkType.MAINNET,
     NetworkType.RINKEBY,
+    NetworkType.GOERLI,
+    NetworkType.ROPSTEN,
+    NetworkType.KOVAN,
   ];
+
+  static networkTypesByClient = {
+    [NodeClient.GETH]: [
+      NetworkType.MAINNET,
+      NetworkType.RINKEBY,
+    ],
+    [NodeClient.ERIGON]: [
+      NetworkType.MAINNET,
+      NetworkType.RINKEBY,
+      NetworkType.GOERLI,
+      NetworkType.ROPSTEN,
+      NetworkType.KOVAN,
+    ],
+  };
 
   static roles = [
     Role.NODE,
@@ -160,16 +230,26 @@ export class Ethereum extends Bitcoin {
   static defaultRPCPort = {
     [NetworkType.MAINNET]: 8545,
     [NetworkType.RINKEBY]: 18545,
+    [NetworkType.GOERLI]: 8545,
+    [NetworkType.ROPSTEN]: 8545,
+    [NetworkType.KOVAN]: 8545,
   };
 
   static defaultPeerPort = {
     [NetworkType.MAINNET]: 8546,
     [NetworkType.RINKEBY]: 18546,
+    [NetworkType.GOERLI]: 30303,
+    [NetworkType.ROPSTEN]: 30303,
+    [NetworkType.KOVAN]: 30303,
   };
 
   static defaultCPUs = 8;
+  static defaultArchivalCPUs = 16;
+  static rpcDaemonCPUs = 2;
 
   static defaultMem = 16384;
+  static defaultArchivalMem = 32768;
+  static rpcDaemonMem = 2048;
 
   static generateConfig(client = Ethereum.clients[0], network = NetworkType.MAINNET, peerPort = Ethereum.defaultPeerPort[NetworkType.MAINNET], rpcPort = Ethereum.defaultRPCPort[NetworkType.MAINNET]): string {
     switch(client) {
@@ -183,7 +263,10 @@ export class Ethereum extends Bitcoin {
     }
   }
 
+  _rpcInstance?: ChildProcess;
+
   id: string;
+  rpcDaemonId: string;
   ticker = 'eth';
   name = 'Ethereum';
   version: string;
@@ -199,6 +282,8 @@ export class Ethereum extends Bitcoin {
   dockerCPUs = Ethereum.defaultCPUs;
   dockerMem = Ethereum.defaultMem;
   dockerNetwork = defaultDockerNetwork;
+  dockerRpcDaemonCPUs = Ethereum.rpcDaemonCPUs;
+  dockerRpcDaemonMem = Ethereum.rpcDaemonMem;
   dataDir = '';
   walletDir = '';
   configPath = '';
@@ -207,17 +292,16 @@ export class Ethereum extends Bitcoin {
   remoteProtocol = '';
   role = Ethereum.roles[0];
 
-  constructor(data: CryptoNodeData, docker?: Docker) {
+  constructor(data: EthCryptoNodeData, docker?: Docker) {
     super(data, docker);
     this.id = data.id || uuid();
+    this.rpcDaemonId = this.id + '-rpc';
     this.network = data.network || NetworkType.MAINNET;
     this.peerPort = data.peerPort || Ethereum.defaultPeerPort[this.network];
     this.rpcPort = data.rpcPort || Ethereum.defaultRPCPort[this.network];
     this.rpcUsername = data.rpcUsername || '';
     this.rpcPassword = data.rpcPassword || '';
     this.client = data.client || Ethereum.clients[0];
-    this.dockerCPUs = data.dockerCPUs || this.dockerCPUs;
-    this.dockerMem = data.dockerMem || this.dockerMem;
     this.dockerNetwork = data.dockerNetwork || this.dockerNetwork;
     this.dataDir = data.dataDir || this.dataDir;
     this.walletDir = data.walletDir || this.walletDir;
@@ -233,16 +317,45 @@ export class Ethereum extends Bitcoin {
     this.clientVersion = data.clientVersion || versionObj.clientVersion || '';
     this.dockerImage = this.remote ? '' : data.dockerImage ? data.dockerImage : (versionObj.image || '');
     this.archival = data.archival || this.archival;
+    this.dockerRpcDaemonCPUs = data.dockerRpcDaemonCPUs || this.dockerRpcDaemonCPUs;
+    this.dockerRpcDaemonMem = data.dockerRpcDaemonMem || this.dockerRpcDaemonMem;
     this.role = data.role || this.role;
+
+    if(this.client === NodeClient.ERIGON) {
+      this.archival = true;
+    }
+
+    if(this.archival) {
+      this.dockerCPUs = data.dockerCPUs || Ethereum.defaultArchivalCPUs;
+      this.dockerMem = data.dockerMem || Ethereum.defaultArchivalMem;
+    } else {
+      this.dockerCPUs = data.dockerCPUs || this.dockerCPUs;
+      this.dockerMem = data.dockerMem || this.dockerMem;
+    }
+
     if(docker)
       this._docker = docker;
   }
 
-  async start(): Promise<ChildProcess> {
+  async start(): Promise<ChildProcess | Array<ChildProcess>> {
     const versions = Ethereum.versions(this.client, this.network);
     const versionData = versions.find(({ version }) => version === this.version) || versions[0];
     if(!versionData)
       throw new Error(`Unknown version ${this.version}`);
+
+    switch (this.client) {
+      case NodeClient.ERIGON:
+        this._logOutput(JSON.stringify(versionData));
+        return this._startErigon(versionData);
+
+      case NodeClient.GETH:
+        return this._startGeth(versionData);
+    }
+
+    throw new Error(`Cannot start ETH node for unknown client: ${this.client}`);
+  }
+
+  async _startGeth(versionData: EthVersionDockerImage): Promise<ChildProcess> {
     const {
       dataDir: containerDataDir,
       walletDir: containerWalletDir,
@@ -287,6 +400,69 @@ export class Ethereum extends Bitcoin {
     return instance;
   }
 
+  async _startErigon(versionData: EthVersionDockerImage): Promise<Array<ChildProcess>> {
+    const { dataDir: containerDataDir } = versionData;
+
+    this._logOutput(JSON.stringify(versionData));
+    if(!versionData.generateRpcRuntimeArgs) {
+      throw new Error('missing generateRpcRuntimeArgs function on version data that is required to run Erigon client');
+    }
+
+    const tmpdir = os.tmpdir();
+    const dataDir = this.dataDir || path.join(tmpdir, uuid());
+    await fs.ensureDir(dataDir);
+
+    const nodeContainerArgs = [
+      '-i',
+      '--rm',
+      '--user=root:root',
+      '--memory', this.dockerMem.toString(10) + 'MB',
+      '--cpus', this.dockerCPUs.toString(10),
+      '--name', this.id,
+      '--network', this.dockerNetwork,
+      '--expose', '9090', // allow rpcdaemon access this container without need to expose on the host.
+      '-p', `${this.peerPort}:${this.peerPort}/tcp`,
+      '-p', `${this.peerPort}:${this.peerPort}/udp`,
+      '-v', `${dataDir}:${containerDataDir}`,
+    ];
+
+    const rpcContainerArgs = [
+      '-i',
+      '--rm',
+      '--memory', this.dockerRpcDaemonMem.toString(10) + 'MB',
+      '--cpus', this.dockerCPUs.toString(10),
+      '--name', this.rpcDaemonId,
+      '--network', this.dockerNetwork,
+      '-p', `${this.rpcPort}:8545`,
+    ];
+
+    await this._docker.pull(this.dockerImage, str => this._logOutput(str));
+    await this._docker.createNetwork(this.dockerNetwork);
+
+    const nodeInstance = this._docker.run(
+      this.dockerImage + versionData.generateRuntimeArgs(this),
+      nodeContainerArgs,
+      output => this._logOutput(output),
+      err => this._logError(err),
+      code => this._logClose(code),
+    );
+
+    const rpcArgs = versionData.generateRpcRuntimeArgs(this);
+
+    const rpcInstance = this._docker.run(
+      this.dockerImage + rpcArgs,
+      rpcContainerArgs,
+      output => this._logOutput(output),
+      err => this._logError(err),
+      code => this._logClose(code),
+    );
+
+    this._instance = nodeInstance;
+    this._rpcInstance = rpcInstance;
+
+    return [ nodeInstance, rpcInstance ];
+  }
+
   generateConfig(): string {
     return Ethereum.generateConfig(
       this.client,
@@ -310,15 +486,24 @@ export class Ethereum extends Bitcoin {
           params: [],
         });
       const { result = '' } = body;
-      // first, check for RC matches
-      let matches = result.match(/v(\d+\.\d+\.\d+-rc.+?)-/i);
-      if(!matches)
-        // check for regular matches
-        matches = result.match(/v(\d+\.\d+\.\d+)/);
-      if(matches && matches.length > 1) {
+
+      if(this.client === NodeClient.ERIGON) {
+        const matches = result.split('/');
+        if(!matches || !matches.length || matches.length < 1) return '';
         return matches[1];
       } else {
-        return '';
+        // first, check for RC matches
+        let matches = result.match(/v(\d+\.\d+\.\d+-rc.+?)-/i);
+        if(!matches)
+          // check for regular matches
+          matches = result.match(/v(\d+\.\d+\.\d+)/);
+        if(matches && matches.length > 1) {
+          return matches[1];
+        } else if(result.length) {
+          return result;
+        } else {
+          return '';
+        }
       }
     } catch(err) {
       this._logError(err);
@@ -406,4 +591,113 @@ export class Ethereum extends Bitcoin {
     return status;
   }
 
+  async _stopRpcDaemon(): Promise<void> {
+    return new Promise<void>(resolve => {
+      if(this._rpcInstance) {
+        const { exitCode } = this._rpcInstance;
+        if (typeof exitCode === 'number') {
+          resolve();
+        } else {
+          this._rpcInstance.on('exit', () => {
+            clearTimeout(timeout);
+            setTimeout(() => {
+              resolve();
+            }, 1000);
+          });
+          this._rpcInstance.kill();
+          const timeout = setTimeout(() => {
+            this._docker.stop(this.rpcDaemonId)
+              .then(() => {
+                setTimeout(() => {
+                  resolve();
+                }, 1000);
+              })
+              .catch(err => {
+                this._logError(err);
+                resolve();
+              });
+          }, 30000);
+        }
+      } else {
+        resolve();
+      }
+    });
+  }
+
+  async stop(): Promise<void> {
+    if(this.client === NodeClient.GETH) {
+      return super.stop();
+    }
+
+    const stopPromises = [
+      this._stopRpcDaemon(),
+      super.stop(),
+    ];
+
+    try {
+      const results = await Promise.allSettled(stopPromises);
+      const rpcStopResult = results[0];
+      if(rpcStopResult.status !== 'fulfilled') {
+        this._logError(
+          new Error(`Erigon RPC Daemon Errored when trying to stop it. ${rpcStopResult.reason}`),
+        );
+      }
+
+      const erigonStopResult = results[1];
+      if(erigonStopResult.status !== 'fulfilled') {
+        this._logError(
+          new Error(`Erigon Node Errored when trying to stop it. ${erigonStopResult.reason}`),
+        );
+      }
+    } catch (e) {
+      this._logError(e);
+    }
+  }
+
+  async getMemUsage(): Promise<[ usagePercent: string, used: string, allocated: string ]> {
+    if(this.client !== NodeClient.ERIGON) return super.getMemUsage();
+
+    try {
+      this._runCheck('getMemUsage');
+      const erigonContainerStats = await this._docker.containerStats(this.id);
+      const rpcContainerStats = await this._docker.containerStats(this.rpcDaemonId);
+
+      const erigonCPUsPercent = Number(erigonContainerStats.MemPerc.replace('%', ''));
+      const rpcDaemonCPUsPercent = Number(rpcContainerStats.MemPerc.replace('%', ''));
+      const percent = `${erigonCPUsPercent + rpcDaemonCPUsPercent}%`;
+
+      const erigon = erigonContainerStats.MemUsage.split('/').map((s: string): string => s.trim());
+      const rpcDaemon = rpcContainerStats.MemUsage.split('/').map((s: string): string => s.trim());
+
+      if(erigon.length > 1 && rpcDaemon.length > 1) {
+        const usage = aggregateStats([ erigon[0], rpcDaemon[0] ]);
+        const allocate = aggregateStats([ erigon[1], rpcDaemon[1] ]);
+
+        return [ percent, usage, allocate ];
+      } else {
+        throw new Error('Split containerStats/MemUsage length less than two.');
+      }
+    } catch (err) {
+      this._logError(err);
+      return [ '0', '0', '0' ];
+    }
+  }
+
+  async getCPUUsage(): Promise<string> {
+    if(this.client !== NodeClient.ERIGON) return super.getCPUUsage();
+
+    try {
+      this._runCheck('getCPUUsage');
+      const erigonContainerStats = await this._docker.containerStats(this.id);
+      const rpcContainerStats = await this._docker.containerStats(this.rpcDaemonId);
+
+      const erigonCPUsPercent = Number(erigonContainerStats.MemPerc.replace('%', ''));
+      const rpcDaemonCPUsPercent = Number(rpcContainerStats.MemPerc.replace('%', ''));
+
+      return `${Math.round((erigonCPUsPercent + rpcDaemonCPUsPercent + Number.EPSILON) * 100) / 100}%`;
+    } catch (err) {
+      this._logError(err);
+      return '0';
+    }
+  }
 }

--- a/src/types/fuse/fuse.ts
+++ b/src/types/fuse/fuse.ts
@@ -167,6 +167,13 @@ export class Fuse extends Ethereum {
     NetworkType.TESTNET,
   ];
 
+  static networkTypesByClient = {
+    [NodeClient.OPEN_ETHEREUM]: [
+      NetworkType.MAINNET,
+      NetworkType.TESTNET,
+    ],
+  };
+
   static roles = [
     Role.NODE,
     Role.VALIDATOR,

--- a/src/types/harmony/harmony.ts
+++ b/src/types/harmony/harmony.ts
@@ -169,6 +169,12 @@ export class Harmony extends Ethereum {
     NetworkType.MAINNET,
   ];
 
+  static networkTypesByClient = {
+    [NodeClient.CORE]: [
+      NetworkType.MAINNET,
+    ],
+  };
+
   static roles = [
     Role.NODE,
   ];

--- a/src/types/lbry/lbry.ts
+++ b/src/types/lbry/lbry.ts
@@ -67,6 +67,13 @@ export class LBRY extends Bitcoin {
     NetworkType.TESTNET,
   ];
 
+  static networkTypesByClient = {
+    [NodeClient.CORE]: [
+      NetworkType.MAINNET,
+      NetworkType.TESTNET,
+    ],
+  };
+
   static roles = [
     Role.NODE,
   ];

--- a/src/types/litecoin/litecoin.ts
+++ b/src/types/litecoin/litecoin.ts
@@ -66,6 +66,13 @@ export class Litecoin extends Bitcoin {
     NetworkType.TESTNET,
   ];
 
+  static networkTypesByClient = {
+    [NodeClient.CORE]: [
+      NetworkType.MAINNET,
+      NetworkType.TESTNET,
+    ],
+  };
+
   static roles = [
     Role.NODE,
   ];

--- a/src/types/pocket/pocket.ts
+++ b/src/types/pocket/pocket.ts
@@ -283,6 +283,13 @@ export class Pocket extends Bitcoin {
     NetworkType.TESTNET,
   ];
 
+  static networkTypesByClient = {
+    [NodeClient.CORE]: [
+      NetworkType.MAINNET,
+      NetworkType.TESTNET,
+    ],
+  };
+
   static defaultRPCPort = {
     [NetworkType.MAINNET]: 8081,
     [NetworkType.TESTNET]: 8081,

--- a/src/types/xdai/xdai.ts
+++ b/src/types/xdai/xdai.ts
@@ -84,6 +84,15 @@ export class Xdai extends Ethereum {
     NetworkType.MAINNET,
   ];
 
+  static networkTypesByClient = {
+    [NodeClient.OPEN_ETHEREUM]: [
+      NetworkType.MAINNET,
+    ],
+    [NodeClient.NETHERMIND]: [
+      NetworkType.MAINNET,
+    ],
+  };
+
   static roles = [
     Role.NODE,
   ];

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,6 +1,24 @@
 import crypto from 'crypto';
 import { VersionDockerImage } from '../interfaces/crypto-node';
 
+export const aggregateStats = function(values: Array<string>): string {
+  const pattern = /(\d*[.,]?\d*)([GM]iB)/;
+
+  const parsedValues: Array<Array<number|string>> = values.map((value) => {
+    const matches = value.match(pattern);
+    if(!matches || !matches.length || matches.length < 2) return ['0', 'MiB'];
+    return [Number(matches[1]), matches[2]];
+  });
+  const hasGiB = parsedValues.some((values: Array<number | string>) => values[1] === 'GiB');
+  let totalInMiB = parsedValues.reduce((acc: number, cur: Array<number | string>) => {
+    const amount = cur[0] as number;
+    const v = cur[1] === 'GiB' ? amount / 1024 : amount;
+    return acc + v;
+  }, 0);
+  if (hasGiB) totalInMiB = totalInMiB * 1024;
+  return `${Math.round((totalInMiB + Number.EPSILON) * 100) / 100}${hasGiB ? 'GiB' : 'MiB'}`;
+};
+
 export const generateRandom = (size = 32): string => {
   return crypto.randomBytes(size).toString('hex');
 };


### PR DESCRIPTION
* Added Erigon Client, Erigon RPC Daemon with support for following Networks: mainnet, rinkeby, goerli, ropsten, kovan, bsc
Added Erigon Test support.
Added common method to parse and aggregate stats like RAM usage/allocate.
Fixed most of the typescript type issues on test.
Fixed most of the error/warning of ESLint for Typescript.

* Removed BSC from Erigon because they remove that support on latest version.

* Revert Commit: Remove Typescript type fixes, ESLint fixes and whitespaces added by IDE.

* Revert "Added Erigon Client, Erigon RPC Daemon with support for following Networks: mainnet, rinkeby, goerli, ropsten, kovan, bsc Added Erigon Test support. Added common method to parse and aggregate stats like RAM usage/allocate. Fixed most of the typescript type issues on test. Fixed most of the error/warning of ESLint for Typescript."

This reverts commit f84e7295

* Rollback changes to remove Typescript, ESLint fixes and CodeStyle whitespaces.